### PR TITLE
cxl/region: Fix uninitialized num_partitions causing incorrect results

### DIFF
--- a/drivers/cxl/core/mbox.c
+++ b/drivers/cxl/core/mbox.c
@@ -1702,6 +1702,7 @@ int cxl_dev_dc_identify(struct cxl_mailbox *mbox,
 	/* Read and check all partition information for validity and potential
 	 * debugging; see debug output in cxl_dc_check() */
 	start_partition = 0;
+	num_partitions = 0;
 	do {
 		int rc, i, j;
 


### PR DESCRIPTION
Initialize num_partitions to zero before parsing partition info in cxl_dev_dc_identify(). Uninitialized value could lead to random data and incorrect results during partition validation.